### PR TITLE
[fix] src: parse disc number from mpd_Song struct into MPDSong

### DIFF
--- a/src/mpdsong.cpp
+++ b/src/mpdsong.cpp
@@ -72,6 +72,7 @@ MPDSong::MPDSong(mpd_InfoEntity *entity) : d(new MPDSongPrivate) {
 		d->comment = QString::fromUtf8(song->comment);
 		d->genre = QString::fromUtf8(song->genre);
 		d->date = QString::fromUtf8(song->date);
+		d->disc = QString::fromUtf8(song->disc);
 		QTime t = QTime(0, 0).addSecs(d->secs);
 		d->time = t.toString(t.hour() > 0 ? "h:mm:ss" : "m:ss");
 	} else


### PR DESCRIPTION
The disc number was not filled in, leading to incorrect sorted lists of releases with multiple discs in the library plane
