### PR TITLE
Add missing config for dynamic playlist icon in oxygen iconset

### DIFF
--- a/icons/oxygen/iconset.conf
+++ b/icons/oxygen/iconset.conf
@@ -30,6 +30,7 @@ clearline=edit-clear.png
 random=roll.png
 repeat=task-recurring.png
 dynamicon=games-solve.png
+dynamic=games-solve.png
 jumpto=go-jump.png
 queue=list-add.png
 dequeue=list-remove.png


### PR DESCRIPTION
Looks like dynamic playlist oxygen icon is missing from UI...so here's a quick fix

![qmpd_oxygen_icon](https://cloud.githubusercontent.com/assets/1910559/9111478/261b399e-3c50-11e5-847d-37f401fee831.png)